### PR TITLE
ribbit.network: Set ribbit.local as the mDNS hostname

### DIFF
--- a/modules/ribbit/network.py
+++ b/modules/ribbit/network.py
@@ -69,10 +69,12 @@ class NetworkManager:
         self,
         config,
         always_on=True,
+        hostname="ribbit",
         poll_interval_connected_ms=5000,
         poll_interval_connecting_ms=500,
     ):
         self._config = config
+        self._hostname = hostname
         self._iface = network.WLAN(network.STA_IF)
         self._iface.active(False)
         self._logger = logging.getLogger(__name__)
@@ -178,6 +180,7 @@ class NetworkManager:
                     self.state.set(_state_connecting)
                     iface.active(False)
                     iface.active(True)
+                    iface.config(hostname=self._hostname)
                     iface.connect(ssid, password)
                     connection_started = True
 


### PR DESCRIPTION
### What?

Expose a user-friendly hostname for the Ribbit sensor on the local network.

Fixes #10

### How?

The Micropython ESP32 port already have (via ESP-IDF) an mDNS responder. We just need to set its hostname properly.