### PR TITLE
Revert "ribbit.network: Set ribbit.local as the mDNS hostname"

### DIFF
--- a/modules/ribbit/network.py
+++ b/modules/ribbit/network.py
@@ -69,12 +69,10 @@ class NetworkManager:
         self,
         config,
         always_on=True,
-        hostname="ribbit",
         poll_interval_connected_ms=5000,
         poll_interval_connecting_ms=500,
     ):
         self._config = config
-        self._hostname = hostname
         self._iface = network.WLAN(network.STA_IF)
         self._iface.active(False)
         self._logger = logging.getLogger(__name__)
@@ -180,7 +178,6 @@ class NetworkManager:
                     self.state.set(_state_connecting)
                     iface.active(False)
                     iface.active(True)
-                    iface.config(hostname=self._hostname)
                     iface.connect(ssid, password)
                     connection_started = True
 


### PR DESCRIPTION
Reverts Ribbit-Network/ribbit-network-frog-software#11

This leads to random software crashes for reasons that are not fully explained yet.