### PR TITLE
ribbit: Add an heartbeat to detect event loop blocking events

### DIFF
--- a/modules/main.py
+++ b/modules/main.py
@@ -63,6 +63,7 @@ async def _main():
     import ribbit.golioth as _golioth
     import ribbit.coap as _coap
     import ribbit.http as _http
+    import ribbit.heartbeat as _heartbeat
 
     if not in_simulator:
         import ribbit.network as _network
@@ -77,6 +78,8 @@ async def _main():
         pass
 
     registry = Registry()
+
+    _heartbeat.Heartbeat(in_simulator)
 
     config_schema = []
     if not in_simulator:

--- a/modules/ribbit/heartbeat.py
+++ b/modules/ribbit/heartbeat.py
@@ -1,0 +1,44 @@
+import time
+import logging
+import uasyncio as asyncio
+
+
+class Heartbeat:
+    def __init__(self, in_simulator):
+        self._in_simulator = in_simulator
+        self._logger = logging.getLogger(__name__)
+
+        if not self._in_simulator:
+            self._setup_pixel()
+        asyncio.create_task(self._loop())
+
+    def _setup_pixel(self):
+        import neopixel
+        import machine
+
+        machine.Pin(21, machine.Pin.OUT, value=1)
+        neo_ctrl = machine.Pin(33, machine.Pin.OUT)
+        self._pixel = neopixel.NeoPixel(neo_ctrl, 1)
+
+    async def _loop(self):
+        interval = 200
+        warn_interval = 300
+
+        on = True
+        px = self._pixel
+
+        while True:
+            if not self._in_simulator:
+                if on:
+                    px[0] = (4, 2, 0)
+                else:
+                    px[0] = (0, 0, 0)
+                on = not on
+                px.write()
+
+            start = time.ticks_ms()
+            await asyncio.sleep_ms(interval)
+            duration = time.ticks_diff(time.ticks_ms(), start)
+
+            if duration > warn_interval:
+                self._logger.warning("Event loop blocked for %d ms", duration - interval)


### PR DESCRIPTION
### What?

This is going to become annoying very quickly, and we are probably going to want to disable this, especially when we start working on power consumption. But:

Add an heartbeat loop. This is a simple loop that sleeps for 200ms and generates a warning if it woke up after more than 300ms. (In addition, it blinks a LED. Because.)

### Why?

Because blocking the event loop for a significant amount of time is the death of collaborative multi-tasking. This is a really important thing to keep an eye on, at least while we are working on this initial version.

### What do we learn from this?

We can see (as we know) that DNS requests are blocking. We can also see random blocking of the event loop outside of that, possibly related to reading sensors from the I2C bus.
