### PR TITLE
Cleanup the CoAP implementation

### DIFF
--- a/modules/ribbit/coap/__init__.py
+++ b/modules/ribbit/coap/__init__.py
@@ -443,7 +443,7 @@ class Coap:
                 sock = ssl.wrap_socket(
                     sock,
                     dtls=True,
-                    do_handshake=True,
+                    do_handshake=False,
                     **self._ssl_opts,
                 )
 

--- a/modules/ribbit/coap/__init__.py
+++ b/modules/ribbit/coap/__init__.py
@@ -156,14 +156,11 @@ class _DTLSocket:
         return self.s.recv_into(buf)
 
     def write(self, buf):
-        if not isinstance(buf, memoryview):
-            buf = memoryview(buf)
-        off = 0
-        while off < len(buf):
+        while True:
             yield _asyncio_core._io_queue.queue_write(self.s)
-            ret = self.s.send(buf[off:])
-            if ret is not None:
-                off += ret
+            r = self.s.send(buf)
+            if r is not None:
+                return r
 
 
 class CoapOption:

--- a/modules/ribbit/coap/__init__.py
+++ b/modules/ribbit/coap/__init__.py
@@ -17,6 +17,8 @@ _MAX_OPTION_NUM = const(10)
 _BUF_MAX_SIZE = const(1500)
 _DEFAULT_PORT = const(5683)
 
+_DEBUG = const(0)
+
 VERSION_UNSUPPORTED = const(0)
 VERSION_1 = const(1)
 
@@ -381,6 +383,8 @@ class Coap:
         ping_interval_ms=60_000,
     ):
         self._logger = logging.getLogger(__name__)
+        if _DEBUG:
+            self._logger.setLevel(logging.DEBUG)
         self._callbacks = {}
         self._response_callback = None
         self._host = host
@@ -528,8 +532,8 @@ class Coap:
         _write_packet_options(buffer, packet)
         _write_packet_payload(buffer, packet)
 
-        # self._logger.info(">>>>>> %s (%d bytes)", packet, len(buffer))
-        # self._logger.info(">>>>>> %s", binascii.hexlify(buffer))
+        if _DEBUG:
+            self._logger.debug(">>>>>> %s", packet)
 
         try:
             await self._sock.write(buffer)
@@ -676,7 +680,8 @@ class Coap:
                 self._force_reconnect("error reading packet")
                 return
 
-            # self._logger.info("<<<<<< %s", packet)
+            if _DEBUG:
+                self._logger.debug("<<<<<< %s", packet)
 
             if packet.type == TYPE_CON:
                 await self._send_ack(packet.message_id)


### PR DESCRIPTION
### What?

Cleanup the CoAP implementation:

 * `_DTLSSocket.write` should not call `send()` multiple times after the first successful write
 * Do the DTLS handshake asynchronously
 * Expose a _DEBUG flag