### PR TITLE
ribbit.config: Simplify the external API

### DIFF
--- a/modules/main.py
+++ b/modules/main.py
@@ -12,7 +12,6 @@ def _setup_improv(registry):
 
     async def _improv_set_wifi_settings(ssid, password):
         registry.config.set(
-            _config.DOMAIN_LOCAL,
             {
                 _network.CONFIG_WIFI_SSID: ssid,
                 _network.CONFIG_WIFI_PASSWORD: password,

--- a/modules/ribbit/config.py
+++ b/modules/ribbit/config.py
@@ -299,7 +299,7 @@ class ConfigRegistry:
                 if not watcher_set:
                     self._watchers.pop(k)
 
-    def set(self, domain, config):
+    def _set(self, domain, config):
         assert domain in _STORED_DOMAINS
 
         new_keys = {}
@@ -328,3 +328,12 @@ class ConfigRegistry:
         for w in affected_watchers:
             values = tuple(self.get(k)[1] for k in w.keys)
             w.notify(values)
+
+    def set(self, config):
+        return self._set(DOMAIN_LOCAL, config)
+
+    def set_remote(self, config):
+        return self._set(DOMAIN_REMOTE, config)
+
+    def set_override(self, config):
+        return self._set(DOMAIN_LOCAL_OVERRIDE, config)

--- a/modules/ribbit/config_test.py
+++ b/modules/ribbit/config_test.py
@@ -14,7 +14,7 @@ def test_config():
         assert foo is None
         assert bar is None
 
-        c.set(_config.DOMAIN_LOCAL, {"foo": "test"})
+        c.set({"foo": "test"})
 
         assert cfg_watcher.changed
         foo, bar = cfg_watcher.get()
@@ -34,22 +34,22 @@ def test_config_override():
         stored=False,
     )
 
-    c.set(_config.DOMAIN_LOCAL, {"bar": 1})
+    c.set({"bar": 1})
     domain, value, _ = c.get("bar")
     assert domain == _config.DOMAIN_LOCAL
     assert value == 1
 
-    c.set(_config.DOMAIN_REMOTE, {"bar": 2})
+    c.set_remote({"bar": 2})
     domain, value, _ = c.get("bar")
     assert domain == _config.DOMAIN_REMOTE
     assert value == 2
 
-    c.set(_config.DOMAIN_REMOTE, {"bar": None})
+    c.set_remote({"bar": None})
     domain, value, _ = c.get("bar")
     assert domain == _config.DOMAIN_LOCAL
     assert value == 1
 
-    c.set(_config.DOMAIN_LOCAL_OVERRIDE, {"bar": 4})
+    c.set_override({"bar": 4})
     domain, value, _ = c.get("bar")
     assert domain == _config.DOMAIN_LOCAL_OVERRIDE
     assert value == 4
@@ -73,20 +73,20 @@ def test_config_array():
         stored=False,
     )
 
-    c.set(_config.DOMAIN_LOCAL, {"bar": []})
+    c.set({"bar": []})
     domain, value, _ = c.get("bar")
     assert domain == _config.DOMAIN_LOCAL
     assert value == []
 
     raised_exc = None
     try:
-        c.set(_config.DOMAIN_LOCAL, {"bar": ["foo"]})
+        c.set({"bar": ["foo"]})
     except Exception as exc:
         raised_exc = exc
 
     assert isinstance(raised_exc, ValueError)
 
-    c.set(_config.DOMAIN_LOCAL, {"bar": [{"foo1": "value1"}]})
+    c.set({"bar": [{"foo1": "value1"}]})
     domain, value, _ = c.get("bar")
     assert domain == _config.DOMAIN_LOCAL
     assert value == [{"foo1": "value1", "foo2": None}]

--- a/modules/ribbit/golioth/__init__.py
+++ b/modules/ribbit/golioth/__init__.py
@@ -121,7 +121,7 @@ class Golioth:
             k = k.replace("_", ".").lower()
             config[k] = v
 
-        self._config.set(_config.DOMAIN_REMOTE, config)
+        self._config.set_remote(config)
 
         await client.post(
             ".c/status",

--- a/modules/ribbit/http.py
+++ b/modules/ribbit/http.py
@@ -64,7 +64,7 @@ def build_app(registry):
             raise HTTPException(400)
 
         try:
-            registry.config.set(DOMAIN_LOCAL, values)
+            registry.config.set(values)
             return "{}", 201, {"Content-Type": "application/json"}
 
         except ValueError as exc:


### PR DESCRIPTION
## What?

Simplify the external API of the config system. There is no reason to force consumers to use constants directly.

## How?

Instead of asking consumers to use the `DOMAIN_LOCAL`, `DOMAIN_REMOTE` and `DOMAIN_LOCAL_OVERRIDE` constants, implement corresponding `set()`, `set_remote()` and `set_override()` methods.