### PR TITLE
Makefile: Make the flash device configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ PORT_DIR := ${MP_DIR}/ports/esp32
 BOARD := ribbit
 BUILD_DIR := ${PORT_DIR}/build-${BOARD}
 
+DEVICE := /dev/ttyACM0
+
 .PHONY: build
 build:
 	rm -f ${BUILD_DIR}/frozen_content.c
@@ -30,7 +32,7 @@ simulator: ${UNIX_DIR}/build-simulator/micropython
 
 .PHONY: flash
 flash: build
-	esptool.py -p /dev/ttyACM* -b 460800 --before default_reset --after no_reset \
+	esptool.py -p ${DEVICE} -b 460800 --before default_reset --after no_reset \
 		--chip esp32s3 \
 		write_flash --flash_mode dio --flash_size detect --flash_freq 80m \
 		0x0 firmware/bootloader.bin \

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ $ make build
 Flash the firmware to a device connected to `/dev/ttyACM*`:
 
 ```shell
-$ make flash
+$ make DEVICE=/dev/ttyACM0 flash
 ```
 
 ## Need Help?


### PR DESCRIPTION
## What?

Allow the device path to be configured during `make flash`.

## How?

Expose a new DEVICE variable, defaulting to `/dev/ttyACM0` (which is the likely path of the device on linux).