### PR TITLE
.gitmodules: Add ignore dirty flag

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,6 +2,8 @@
 	path = vendor/micropython
 	url = https://github.com/damz/micropython.git
 	branch = pr/mbedtls
+	ignore = dirty
 [submodule "vendor/microdot"]
 	path = vendor/microdot
 	url = https://github.com/miguelgrinberg/microdot.git
+	ignore = dirty


### PR DESCRIPTION
## What?

In #22, @akhilgupta1093 noted that it was very easy to accidentally add build artifacts generated in submodule directories to PRs from your local copy. This changeset was discussed in Discord as a way to prevent developers from accidentally adding modified submodule directories to PRs and shared braches etc.

## How?

Add the ignore = dirty flag to:
* vendor/micropython
* vendor/microdot

From: https://web.archive.org/web/20200808000111/http://www.nils-haldenwang.de/frameworks-and-tools/git/how-to-ignore-changes-in-git-submodules