### PR TITLE
Fixes #30: GPS Lat/Long Obfuscation

### DIFF
--- a/modules/ribbit/sensors/gps.py
+++ b/modules/ribbit/sensors/gps.py
@@ -28,6 +28,17 @@ def _append_checksum(packet):
         checksum,
     )
 
+def _obfuscate_gps_coordinate(coordinate):
+    """
+    Returns the coordinate, rounded to 2 digits of precision.
+    
+    Github Issue: #30
+    https://github.com/Ribbit-Network/ribbit-network-frog-software/issues/30
+    """
+    gps_digits_precision = 2
+
+    obfuscated = round(coordinate, gps_digits_precision)
+    return obfuscated
 
 class GPS(_base.BaseSensor):
     config = _config.Object(
@@ -192,8 +203,12 @@ class GPS(_base.BaseSensor):
                     longitude = None
 
                 self.last_fix = self.last_update
-                self.latitude = latitude
-                self.longitude = longitude
+
+                # Lat and Long are obfuscated here before storate to
+                # ensure that precise coordinates never make it to any
+                # logs or data storage.
+                self.latitude = _obfuscate_gps_coordinate(latitude)
+                self.longitude = _obfuscate_gps_coordinate(longitude)
 
                 altitude_raw = parts[8]
                 if altitude_raw != b"":

--- a/modules/ribbit/sensors/gps_test.py
+++ b/modules/ribbit/sensors/gps_test.py
@@ -5,3 +5,19 @@ def test_checksum():
         _append_checksum(b"$PMTK314,0,0,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0")
         == b"$PMTK314,0,0,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0*29\r\n"
     )
+
+
+def test_location_obfuscation():
+    from ribbit.sensors.gps import _obfuscate_gps_coordinate
+
+    assert (
+        _obfuscate_gps_coordinate(47.6350688) == 47.64
+    )
+
+    assert (
+        _obfuscate_gps_coordinate(-122.3208268) == -122.32
+    )
+
+    assert (
+        _obfuscate_gps_coordinate(0.0000000001) == 0.00
+    )


### PR DESCRIPTION
This change is to round the latitude and longitude coordinates to
 0.01 degrees of precision (2 decimal places).

It allows privacy protection for the installer of the Frog sensor, as it will not be possible for someone to precisely determine the location of the sensor.

Also adds unit test to confirm rounding behavior