### PR TITLE
utils.ota: Mark partition as valid after first boot

### DIFF
--- a/modules/main.py
+++ b/modules/main.py
@@ -73,6 +73,7 @@ async def _main():
     import ribbit.sensors.scd30 as _scd30
     import ribbit.time_manager as _time
     import ribbit.utils.i2c as _i2c
+    import ribbit.utils.ota as _ota
 
     class Registry:
         pass
@@ -143,8 +144,11 @@ async def _main():
         registry.network = _network.NetworkManager(registry.config)
         registry.time_manager = _time.TimeManager(registry.network)
 
+    registry.ota_manager = _ota.OTAManager(in_simulator=in_simulator)
+
     registry.golioth = _golioth.Golioth(
         registry.config,
+        ota_manager=registry.ota_manager,
         in_simulator=in_simulator,
     )
 
@@ -201,6 +205,8 @@ async def _main():
 
     if not in_simulator:
         _setup_improv(registry)
+
+    registry.ota_manager.successful_boot()
 
     app = _http.build_app(registry)
     asyncio.create_task(

--- a/modules/ribbit/golioth/__init__.py
+++ b/modules/ribbit/golioth/__init__.py
@@ -59,12 +59,12 @@ CONFIG_KEYS = [
 
 
 class Golioth:
-    def __init__(self, config, commands=None, in_simulator=False):
+    def __init__(self, config, ota_manager, commands=None, in_simulator=False):
         self._logger = logging.getLogger(__name__)
         self._config = config
         self._commands = commands or {}
         self._coap = None
-        self._ota_manager = _ota.OTAManager()
+        self._ota_manager = ota_manager
         self._in_simulator = in_simulator
         self._ota_enabled = False
 

--- a/modules/ribbit/heartbeat.py
+++ b/modules/ribbit/heartbeat.py
@@ -10,7 +10,7 @@ class Heartbeat:
 
         if not self._in_simulator:
             self._setup_pixel()
-        asyncio.create_task(self._loop())
+            asyncio.create_task(self._loop())
 
     def _setup_pixel(self):
         import neopixel

--- a/modules/ribbit/utils/ota.py
+++ b/modules/ribbit/utils/ota.py
@@ -11,13 +11,23 @@ class OTAUpdate:
 
 
 class OTAManager:
-    def __init__(self):
+    def __init__(self, in_simulator=False):
         self._logger = logging.getLogger(__name__)
+        self._in_simulator = in_simulator
 
     def successful_boot(self):
+        if self._in_simulator:
+            self._logger.info("Running in simulator: skipping successful boot")
+            return
+
+        import esp32
         esp32.Partition.mark_app_valid_cancel_rollback()
 
     async def do_ota_update(self, u):
+        if self._in_simulator:
+            self._logger.info("Running in simulator: skipping update")
+            return
+
         import esp32
 
         self._logger.info("Starting OTA update")


### PR DESCRIPTION
### Why?

The OTA upgrade process uses an A/B upgrade method. After rebooting into the new firmware, we need to mark the new partition as valid by calling `esp32.Partition.mark_app_valid_cancel_rollback()`. Unfortunately, this was missed after a couple of refactorings of the OTA code.

### What?

* Call `OTAManager.successful_boot()` at the bottom of the main function.
* Refactor how the `OTAManager` class is instantiated and injected into the `Golioth` class.
* Fix `Heartbeat` when running in the simulator
