### PR TITLE
#33: Add block retry to OTA

### DIFF
--- a/modules/ribbit/coap/__init__.py
+++ b/modules/ribbit/coap/__init__.py
@@ -751,16 +751,25 @@ class BlockReader:
             OPTION_BLOCK2,
             block_option_payload,
         )
-        response = await self._client.request(packet)
 
-        options = [
-            option for option in response.options if option.number == OPTION_BLOCK2
-        ]
-        if (
-            len(options) != 1
-            or (decode_uint_option(options[0].buffer) >> 4) != self._block_num
-        ):
-            raise RuntimeError("unexpected block option in server response")
+        num_retries = 1
+        for i in range(num_retries+1):
+            response = await self._client.request(packet)
+            options = [
+                option for option in response.options if option.number == OPTION_BLOCK2
+            ]
+            if (
+                len(options) != 1
+                or (decode_uint_option(options[0].buffer) >> 4) != self._block_num
+            ):
+                # The server has unexpectedly sent a OPTION_BLOCK2 packet with an
+                # unexpected header. This is possibly due to a very slow connection on
+                # the device causing the server to expire the update package.
+                # In this case, try rerquesting the packet once more before
+                # throwing an exception in case the server did tiemout.
+                # See https://github.com/Ribbit-Network/ribbit-network-frog-software/issues/33
+                if i == num_retries:
+                    raise RuntimeError("unexpected block option in server response")
 
         if len(buf) < len(response.payload):
             raise ValueError("buffer too small")

--- a/modules/ribbit/coap/__init__.py
+++ b/modules/ribbit/coap/__init__.py
@@ -752,9 +752,10 @@ class BlockReader:
             block_option_payload,
         )
 
-        num_retries = 1
-        for i in range(num_retries+1):
+        num_retries = 0
+        while True:
             response = await self._client.request(packet)
+
             options = [
                 option for option in response.options if option.number == OPTION_BLOCK2
             ]
@@ -768,9 +769,13 @@ class BlockReader:
                 # In this case, try rerquesting the packet once more before
                 # throwing an exception in case the server did tiemout.
                 # See https://github.com/Ribbit-Network/ribbit-network-frog-software/issues/33
-                if i == num_retries:
+                if num_retries == 1:
                     raise RuntimeError("unexpected block option in server response")
+                num_retries += 1
+                continue
 
+            break
+                    
         if len(buf) < len(response.payload):
             raise ValueError("buffer too small")
 

--- a/modules/ribbit/utils/ota.py
+++ b/modules/ribbit/utils/ota.py
@@ -60,7 +60,12 @@ class OTAManager:
 
             n = 0
             while n < len(dest_buf):
-                sz = await u.reader.readinto(dest_buf[n:])
+                try:
+                    sz = await u.reader.readinto(dest_buf[n:])
+                except:
+                    self._logger.warning("Exception processing coap block id %d. Trying again.", block_id)
+                    # Attempt to read this block again
+                    continue
                 if sz == 0:
                     break
                 n += sz

--- a/modules/ribbit/utils/ota.py
+++ b/modules/ribbit/utils/ota.py
@@ -60,12 +60,7 @@ class OTAManager:
 
             n = 0
             while n < len(dest_buf):
-                try:
-                    sz = await u.reader.readinto(dest_buf[n:])
-                except:
-                    self._logger.warning("Exception processing coap block id %d. Trying again.", block_id)
-                    # Attempt to read this block again
-                    continue
+                sz = await u.reader.readinto(dest_buf[n:])
                 if sz == 0:
                     break
                 n += sz


### PR DESCRIPTION
In #33 I documented a problem with my devices with slower cellular connections failing to receive an update.

The problem seems to be that the device receives an unexpected block from golioth server, which throws an unhandled exception and stops the update process.

This change adds some basic retry logic if there is an exception processing a block, which in testing, allows my devices to successfully update.