### PR TITLE
Create aggregated sensor message

### DIFF
--- a/modules/main.py
+++ b/modules/main.py
@@ -59,6 +59,7 @@ async def _main():
         sys.path.append(os.getcwd() + "/../vendor/microdot/src")
         sys.path.append(os.getcwd() + "/..")
 
+    import ribbit.aggregate as _aggregate
     import ribbit.config as _config
     import ribbit.golioth as _golioth
     import ribbit.coap as _coap
@@ -80,6 +81,7 @@ async def _main():
 
     registry = Registry()
 
+    _aggregate.SensorAggregator(registry)
     _heartbeat.Heartbeat(in_simulator)
 
     config_schema = []
@@ -170,13 +172,6 @@ async def _main():
                 try:
                     typ = item.pop("@type")
                     data = json.dumps(item)
-                    self._logger.info("Data packet %s: %s", typ, data)
-
-                    await coap.post(
-                        ".s/" + typ,
-                        data,
-                        format=_coap.CONTENT_FORMAT_APPLICATION_JSON,
-                    )
                 except Exception:
                     pass
 

--- a/modules/ribbit/aggregate.py
+++ b/modules/ribbit/aggregate.py
@@ -1,0 +1,58 @@
+from ribbit.utils.time import isotime
+import time
+import logging
+import uasyncio as asyncio
+import collections
+import json
+
+import ribbit.coap as _coap
+
+
+class SensorAggregator:
+    def __init__(self, registry):
+        self._logger = logging.getLogger(__name__)
+        self._registry = registry
+
+        asyncio.create_task(self._loop())
+
+
+    async def _loop(self):
+        while True:
+            # Send a data point every 5 seconds
+            await asyncio.sleep_ms(5000)
+
+            ret = collections.OrderedDict()
+            for sensor in self._registry.sensors.values():
+                if sensor.config.name == "dps310":
+                    ret[sensor.config.name] = {
+                        "temperature": sensor.temperature,
+                        "pressure": sensor.pressure,
+                        "t": isotime(sensor.last_update),
+                    }
+                elif sensor.config.name == "scd30":
+                    ret[sensor.config.name] = {
+                        "temperature": sensor.temperature,
+                        "co2": sensor.co2,
+                        "humidity": sensor.humidity,
+                        "t": isotime(sensor.last_update),
+                    }
+                elif sensor.config.name == "gps":
+                    ret[sensor.config.name] = {
+                        "has_fix": sensor.has_fix,
+                        "latitude": sensor.latitude,
+                        "longitude": sensor.longitude,
+                        "altitude": sensor.altitude,
+                        "t": isotime(sensor.last_update),
+                    }
+
+
+            self._logger.info("Aggregated Data: %s", json.dumps(ret))
+            try:
+                coap = self._registry.golioth._coap
+                await coap.post(
+                    ".s/" + "ribbitnetwork.datapoint",
+                    json.dumps(ret),
+                    format=_coap.CONTENT_FORMAT_APPLICATION_JSON,
+                )
+            except Exception:
+                pass


### PR DESCRIPTION
### Why

We need to find a way to connect the new V4 sensor software to the database used for the V1-3 sensors so that they show up on the public map: https://dashboard.ribbitnetwork.org/

### How

As discussed on Discord, there are two possible paths:

- The first path is to give the sensors an influxdb token, and just send the data in the legacy format to influxdb directly from the sensor.
- The second path is to have a process somewhere that picks up the data we already have in Google Pub/sub, massages it in the legacy format and sends it to influxdb.

The second option is advantageous as it eliminates the need for the sensors to hold the InfluxDB write key, which is a bit of a security risk.

In order to achieve this, the sensor should publish only one message to Golioth's LightDB service that contains the current state of all sensors. This eliminates the need for a complex backend service to aggregate the messages and hold the required state to write a datapoint into influxDB.


### Testing

I have tested this on a test golioth fleet and confirmed all is well:

<img width="1043" alt="image" src="https://user-images.githubusercontent.com/2559382/214519667-82fcb5ce-368c-4ce7-8e8c-6b0e93975b7f.png">

