### PR TITLE
Add memory stats to device logging.

### DIFF
--- a/modules/ribbit/aggregate.py
+++ b/modules/ribbit/aggregate.py
@@ -44,6 +44,11 @@ class SensorAggregator:
                         "altitude": sensor.altitude,
                         "t": isotime(sensor.last_update),
                     }
+                elif sensor.config.name == "memory":
+                    ret[sensor.config.name] = {
+                        "allocated": sensor.allocated,
+                        "total": sensor.total,
+                    }
 
 
             self._logger.info("Aggregated Data: %s", json.dumps(ret))


### PR DESCRIPTION
This change adds the device allocated and device total memory information to the logged status message sent to the cloud.

This is to assist in debugging a potential issue seen in #41 