### PR TITLE
sensors.board: Fix memory sensor

### DIFF
--- a/modules/ribbit/sensors/board.py
+++ b/modules/ribbit/sensors/board.py
@@ -56,6 +56,6 @@ class Memory(_base.PollingSensor):
             "t": isotime(time.time()),
             "@type": "ribbitnetwork.sensor.DeviceMemory",
             "sensor_model": "frog",
-            "allocated": allocated,
-            "total": alloc + free,
+            "allocated": self.allocated,
+            "total": self.allocated + self.free,
         }


### PR DESCRIPTION
Fix an exception raised in the memory sensor collection loop, introduced by ec916d01cb0dbc12801cc80cf23176b3956e9224

Fixes #46