### PR TITLE
board: Disable some unused ESP-IDF features

### DIFF
--- a/board/mpconfigboard.h
+++ b/board/mpconfigboard.h
@@ -11,3 +11,7 @@
 #define MICROPY_HW_I2C0_SDA                 (3)
 
 #define MICROPY_ENABLE_COMPILER             (1)
+
+#define MICROPY_PY_ESPNOW                   (0)
+#define MICROPY_PY_MACHINE_I2S              (0)
+#define MICROPY_HW_ENABLE_SDCARD            (0)


### PR DESCRIPTION
This gives us some breathing room in terms of firmware size.

Before this PR:

```
micropython.bin binary size 0x17d030 bytes. Smallest app partition is 0x180000 bytes. 0x2fd0 bytes (1%) free.
Warning: The smallest app partition is nearly full (1% free space left)!
```

After this PR:

```
micropython.bin binary size 0x16e250 bytes. Smallest app partition is 0x180000 bytes. 0x11db0 bytes (5%) free.
```

So a gain of about 50 kB.