### PR TITLE
ribbit.time_manager: Record and report boot time

### DIFF
--- a/modules/main.py
+++ b/modules/main.py
@@ -80,6 +80,7 @@ async def _main():
         pass
 
     registry = Registry()
+    registry.in_simulator = in_simulator
 
     _aggregate.SensorAggregator(registry)
     _heartbeat.Heartbeat(in_simulator)
@@ -144,7 +145,8 @@ async def _main():
 
     if not in_simulator:
         registry.network = _network.NetworkManager(registry.config)
-        registry.time_manager = _time.TimeManager(registry.network)
+
+    registry.time_manager = _time.TimeManager(registry)
 
     registry.ota_manager = _ota.OTAManager(in_simulator=in_simulator)
 

--- a/modules/ribbit/aggregate.py
+++ b/modules/ribbit/aggregate.py
@@ -15,7 +15,6 @@ class SensorAggregator:
 
         asyncio.create_task(self._loop())
 
-
     async def _loop(self):
         while True:
             # Send a data point every 5 seconds
@@ -50,6 +49,8 @@ class SensorAggregator:
                         "free": sensor.free,
                     }
 
+
+            ret["time_manager"] = self._registry.time_manager.export()
 
             self._logger.info("Aggregated Data: %s", json.dumps(ret))
             try:


### PR DESCRIPTION
This PR records the initial boot time of the sensor (as defined as the first valid time we have acquired), and adds a new `time_manager` section to the aggregated sensor data:

```js
"time_manager": {
  "has_valid_time": true,                     // Whether we have a valid time or not
  "source": "simulator",                      // The last source of the time ("unknown", "ntp", "gps", "simulator")
  "last_update": "2024-01-17T00:10:54Z",      // The last time the time was updated (or null if the time is unknown)
  "boot_time": "2024-01-17T00:10:54Z",        // The first time we recorded since the boot of the sensor
}
```