### PR TITLE
sensors: Add scd30.force_calibration remote command

### DIFF
--- a/modules/main.py
+++ b/modules/main.py
@@ -98,6 +98,16 @@ async def _main():
         "memory": _board.Memory,
     }
 
+    commands = {}
+
+    for sensor_cls in sensor_types.values():
+        commands_factory = getattr(sensor_cls, "commands", None)
+        if commands_factory is None:
+            continue
+
+        for command_name, command in commands_factory().items():
+            commands[command_name] = command
+
     default_sensors = [
         {
             "type": "board",
@@ -151,9 +161,10 @@ async def _main():
     registry.ota_manager = _ota.OTAManager(in_simulator=in_simulator)
 
     registry.golioth = _golioth.Golioth(
-        registry.config,
+        registry,
         ota_manager=registry.ota_manager,
         in_simulator=in_simulator,
+        commands=commands,
     )
 
     registry.sensors = {}

--- a/modules/ribbit/sensors/base.py
+++ b/modules/ribbit/sensors/base.py
@@ -10,6 +10,23 @@ class BaseSensor:
         self._logger = logging.getLogger("sensor." + self.config.name)
 
 
+def find_sensor_by_id(registry, id, cls=None):
+    for sensor in registry.sensors.values():
+        if sensor._sensor_id == id and (cls is None or sensor.__class__ is cls):
+            return sensor
+
+    raise ValueError(f"Unknown sensor id ({id})")
+
+
+def sensor_command(cls, command_method_name):
+    def _command(registry, method, params):
+        id = params.pop(0)
+        sensor = find_sensor_by_id(registry, id, cls=cls)
+        return getattr(sensor, command_method_name)(params)
+
+    return _command
+
+
 class PollingSensor(BaseSensor):
     def __init__(self, registry, id, interval):
         super().__init__(registry, id)

--- a/modules/ribbit/sensors/scd30.py
+++ b/modules/ribbit/sensors/scd30.py
@@ -207,6 +207,23 @@ class SCD30(_base.PollingSensor):
         self.temperature = temperature
         self.humidity = humidity
 
+    @classmethod
+    def commands(cls):
+        return {
+            "scd30.force_calibration": _base.sensor_command(cls, "_force_calibration"),
+        }
+
+    async def _force_calibration(self, params):
+        if len(params) != 1:
+            raise ValueError()
+
+        value = int(params[0])
+
+        await self._send_command(
+            _CMD_SET_FORCED_RECALIBRATION_FACTOR,
+            value,
+        )
+
     def export(self):
         t = isotime(self.last_update)
         sensor_id = self._sensor_id


### PR DESCRIPTION
This PR adds a `scd30.force_calibration` RPC command that forces a calibration of the SCD30 CO2 sensor, in addition to the infrastructure necessary to allow sensors to implement commands.